### PR TITLE
Handle negated globs (starting with `!`)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,14 +4,14 @@
 import path from 'node:path';
 import process from 'node:process';
 import readdir from 'tiny-readdir';
-import {castArray, globsExplode, globsCompile, ignoreCompile, intersection, uniqFlat, uniqMergeConcat} from './utils';
+import {castArray, globsExplode, globsCompile, handleNegatedGlobs, ignoreCompile, intersection, uniqFlat, uniqMergeConcat} from './utils';
 import type {Dirent, Options, Result} from './types';
 
 /* MAIN */
 
 const readdirGlob = async ( glob: string | string[], options?: Options ): Promise<Result> => {
 
-  const globs = castArray ( glob );
+  const globs = handleNegatedGlobs ( castArray ( glob ), options );
   const cwd = options?.cwd ?? process.cwd ();
 
   const bucketDirectories: string[][] = [];

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,9 +9,9 @@ import type {Dirent, Options, Result} from './types';
 
 /* MAIN */
 
-const readdirGlob = async ( glob: string | string[], options?: Options ): Promise<Result> => {
+const readdirGlob = async ( glob: string | string[], opts?: Options ): Promise<Result> => {
 
-  const globs = handleNegatedGlobs ( castArray ( glob ), options );
+  const { filteredGlobs: globs, options } = handleNegatedGlobs ( castArray ( glob ), opts );
   const cwd = options?.cwd ?? process.cwd ();
 
   const bucketDirectories: string[][] = [];

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -168,6 +168,12 @@ const handleNegatedGlobs = ( globs: string[], options?: Options ): { filteredGlo
     return { filteredGlobs, options };
   }
 
+  // If there are no "positive" globs but some negated ones, we want to implicitly add "**" to
+  // match everything but the negated patterns.
+  if ( !filteredGlobs.length ) {
+    filteredGlobs.push("**");
+  }
+
   if ( options ) {
     if ( !options.ignore ) {
       options.ignore = ignoresToAdd;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,7 +6,7 @@ import zeptomatch from 'zeptomatch';
 import {explodeStart, explodeEnd} from 'zeptomatch-explode';
 import isStatic from 'zeptomatch-is-static';
 import unescape from 'zeptomatch-unescape';
-import type {ArrayMaybe} from './types';
+import type {ArrayMaybe, Options} from './types';
 
 /* MAIN */
 
@@ -142,6 +142,41 @@ const ignoreCompile = ( rootPath: string, ignore?: ArrayMaybe<(( targetPath: str
 
 };
 
+/** 
+ * Filters out negated glob patterns and adds them to `options.ignore` as a side effect.\
+ * E.g. `handleNegatedGlobs ( ['*.js', '!no-match.js'], {} )` returns `['*.js']`, and\
+ * `options.ignore` becomes `['no-match.js']`.
+ */
+const handleNegatedGlobs = ( globs: string[], options?: Options ): string[] => {
+  const ignoresToAdd: string[] = [];
+  const filteredGlobs = globs.filter(glob => {
+    if ( !glob.startsWith ('!') ) {
+      return true;
+    }
+
+    ignoresToAdd.push ( glob.slice(1) );
+    return false;
+  })
+
+  if ( !ignoresToAdd.length ) {
+    return filteredGlobs;
+  }
+
+  if ( options ) {
+    if ( !options.ignore ) {
+      options.ignore = ignoresToAdd;
+    } else {
+      const newIgnores = castArray ( options.ignore );
+      newIgnores.push ( ...ignoresToAdd );
+      options.ignore = newIgnores;
+    }
+  } else {
+    options = { ignore: ignoresToAdd };
+  }
+
+  return filteredGlobs;
+}
+
 const intersection = <T> ( sets: Set<T>[] ): Set<T> => {
 
   if ( sets.length === 1 ) return sets[0];
@@ -225,4 +260,4 @@ const uniqMergeConcat = <T> ( values: Record<string, T[]>[] ): Record<string, T[
 
 /* EXPORT */
 
-export {castArray, globExplode, globsExplode, globCompile, globsCompile, ignoreCompile, intersection, isPathSep, isString, uniq, uniqFlat, uniqMergeConcat};
+export {castArray, globExplode, globsExplode, globCompile, globsCompile, handleNegatedGlobs, ignoreCompile, intersection, isPathSep, isString, uniq, uniqFlat, uniqMergeConcat};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -143,13 +143,13 @@ const ignoreCompile = ( rootPath: string, ignore?: ArrayMaybe<(( targetPath: str
 };
 
 /** 
- * Filters out negated glob patterns and adds them to `options.ignore` as a side effect.\
+ * Filters out negated glob patterns and adds them to `options.ignore`.\
  * E.g. `handleNegatedGlobs ( ['*.js', '!no-match.js'], {} )` returns `['*.js']`, and\
  * `options.ignore` becomes `['no-match.js']`.
  */
-const handleNegatedGlobs = ( globs: string[], options?: Options ): string[] => {
+const handleNegatedGlobs = ( globs: string[], options?: Options ): { filteredGlobs: string[], options?: Options } => {
   const ignoresToAdd: string[] = [];
-  const filteredGlobs = globs.filter(glob => {
+  const filteredGlobs = globs.filter ( glob => {
     if ( !glob.startsWith ('!') ) {
       return true;
     }
@@ -159,7 +159,7 @@ const handleNegatedGlobs = ( globs: string[], options?: Options ): string[] => {
   })
 
   if ( !ignoresToAdd.length ) {
-    return filteredGlobs;
+    return { filteredGlobs, options };
   }
 
   if ( options ) {
@@ -174,7 +174,7 @@ const handleNegatedGlobs = ( globs: string[], options?: Options ): string[] => {
     options = { ignore: ignoresToAdd };
   }
 
-  return filteredGlobs;
+  return { filteredGlobs, options };
 }
 
 const intersection = <T> ( sets: Set<T>[] ): Set<T> => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -149,14 +149,20 @@ const ignoreCompile = ( rootPath: string, ignore?: ArrayMaybe<(( targetPath: str
  */
 const handleNegatedGlobs = ( globs: string[], options?: Options ): { filteredGlobs: string[], options?: Options } => {
   const ignoresToAdd: string[] = [];
-  const filteredGlobs = globs.filter ( glob => {
-    if ( !glob.startsWith ('!') ) {
-      return true;
+  const filteredGlobs = globs.reduce<string[]> ( ( filtered, glob ) => {
+    let i = 0;
+    while ( glob[i] === "!" ) {
+      i += 1;
     }
 
-    ignoresToAdd.push ( glob.slice(1) );
-    return false;
-  })
+    if ( i % 2 === 0 ) {
+      filtered.push( glob.slice ( i ) );
+    } else {
+      ignoresToAdd.push( glob.slice ( i ) );
+    }
+
+    return filtered;
+  }, [] );
 
   if ( !ignoresToAdd.length ) {
     return { filteredGlobs, options };

--- a/test/index.js
+++ b/test/index.js
@@ -129,6 +129,27 @@ describe ( 'Tiny Readdir Glob', it => {
 
       t.is ( result5.files.length, 4 );
 
+      const expected6 = {
+        files: [],
+        directories: [],
+        symlinks: [],
+        filesFound: [file1aPath, file2Path],
+        directoriesFound: [],
+        symlinksFound: [],
+        directoriesFoundNames: new Set ([]),
+        filesFoundNames: new Set ([ 'file1a.txt', 'file2.txt' ]),
+        symlinksFoundNames: new Set ([]),
+        directoriesFoundNamesToPaths: {},
+        filesFoundNamesToPaths: { 'file1a.txt': [file1aPath], 'file2.txt': [file2Path] },
+        symlinksFoundNamesToPaths: {}
+      };
+
+      const result6a = await readdir ( ['folder1/**/*.js', 'folder2/**/*.js', '!**/deep/**'], { cwd: root1Path, followSymlinks: true, ignore: 'file1b.txt' } );
+      const result6b = await readdir ( ['folder1/**/*.js', 'folder2/**/*.js', '!**/deep/**', '!file1b.txt'], { cwd: root1Path, followSymlinks: true } );
+      
+      t.deepEqual ( result6a, expected6 );
+      t.deepEqual ( result6b, expected6 );
+
     } finally {
 
       fs.rmSync ( root1Path, { recursive: true } );

--- a/test/index.js
+++ b/test/index.js
@@ -151,6 +151,25 @@ describe ( 'Tiny Readdir Glob', it => {
       t.deepEqual ( result6a, expected6 );
       t.deepEqual ( result6b, expected6 );
       t.deepEqual ( result6c, expected6 );
+
+      const expected7 = {
+        files: [file1aPath, file1bPath, file2Path],
+        directories: [folder1Path, folder2Path, root2Path],
+        symlinks: [symlink1FromPath, symlink2FromPath],
+        filesFound: [file1aPath, file1bPath, file2Path],
+        directoriesFound: [folder1Path, folder2Path, root2Path],
+        symlinksFound: [symlink1FromPath, symlink2FromPath],
+        directoriesFoundNames: new Set ([ 'folder1', 'folder2', 'root2' ]),
+        filesFoundNames: new Set ([ 'file1a.txt', 'file1b.txt', 'file2.txt' ]),
+        symlinksFoundNames: new Set ([ 'symlink' ]),
+        directoriesFoundNamesToPaths: { folder1: [folder1Path], folder2: [folder2Path], root2: [root2Path] },
+        filesFoundNamesToPaths: { 'file1a.txt': [file1aPath], 'file1b.txt': [file1bPath], 'file2.txt': [file2Path] },
+        symlinksFoundNamesToPaths: { symlink: [symlink1FromPath, symlink2FromPath] }
+      };
+
+      const result7 = await readdir ( ['!**/deep/**'], { cwd: root1Path, followSymlinks: true } );
+
+      t.deepEqual ( result7, expected7 );
       
     } finally {
 

--- a/test/index.js
+++ b/test/index.js
@@ -146,10 +146,12 @@ describe ( 'Tiny Readdir Glob', it => {
 
       const result6a = await readdir ( ['folder1/**/*.js', 'folder2/**/*.js', '!**/deep/**'], { cwd: root1Path, followSymlinks: true, ignore: 'file1b.txt' } );
       const result6b = await readdir ( ['folder1/**/*.js', 'folder2/**/*.js', '!**/deep/**', '!file1b.txt'], { cwd: root1Path, followSymlinks: true } );
-      
+      const result6c = await readdir ( ['!!folder1/**/*.js', '!!!!folder2/**/*.js', '!!!**/deep/**', '!!!!!file1b.txt'], { cwd: root1Path, followSymlinks: true })
+
       t.deepEqual ( result6a, expected6 );
       t.deepEqual ( result6b, expected6 );
-
+      t.deepEqual ( result6c, expected6 );
+      
     } finally {
 
       fs.rmSync ( root1Path, { recursive: true } );


### PR DESCRIPTION
Before compiling and further processing the globs, we take the ones starting with `!` and add them to `options.ignore`.