### PR TITLE
Bump `zeptomatch` dependencies to the latest versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,10 +25,10 @@
   ],
   "dependencies": {
     "tiny-readdir": "^2.7.0",
-    "zeptomatch": "^1.2.2",
-    "zeptomatch-explode": "^1.0.0",
-    "zeptomatch-is-static": "^1.0.0",
-    "zeptomatch-unescape": "^1.0.0"
+    "zeptomatch": "^2.0.1",
+    "zeptomatch-explode": "^1.0.1",
+    "zeptomatch-is-static": "^1.0.1",
+    "zeptomatch-unescape": "^1.0.1"
   },
   "devDependencies": {
     "@types/node": "^20.9.4",


### PR DESCRIPTION
Fixes #5.

The regex created in https://github.com/fabiospampinato/tiny-readdir-glob/blob/dd837942ed955b5633382fb90b9dc8bb4bb1746f/src/utils.ts#L109 ends up being `^[^/]*\.json$` in old `zeptomatch` versions, but `path.relative` a few lines below returns paths with forward slashes on Linux, and with backslashes on Windows. This causes false positives when testing against that regex.

`zeptomatch` fixes that in https://github.com/fabiospampinato/zeptomatch/commit/f589338f03bbe18b3ced59296c0f653c7e4fe432 and generates a regular expression that correctly handles Windows vs Unix-like paths.